### PR TITLE
Add Redirect Link for LampungDev Discord Community

### DIFF
--- a/src/app/join-discord/page.tsx
+++ b/src/app/join-discord/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function RegisterPage() {
+  redirect('https://discord.gg/EZsEN6ftP2');
+}


### PR DESCRIPTION
## Description
To make it easier for users to join the LampungDev Discord community, add a redirect route in our Next.js app. This route should redirect anyone accessing /join-discord directly to our official Discord invite link.

Fixes #11 