### PR TITLE
feat(contributors) : Add contributors page on public routes

### DIFF
--- a/src/app/(public)/contributors/loading.tsx
+++ b/src/app/(public)/contributors/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const LoadingContributorCard = () => (
+  <div className="w-full border border-white flex flex-col justify-center items-center p-4 md:p-6 rounded-lg backdrop-blur-sm bg-green-600/10">
+    <Skeleton className="w-20 h-20 md:w-24 md:h-24 lg:w-28 lg:h-28 rounded-full" />
+    <Skeleton className="mt-3 md:mt-4 h-6 w-32" />
+    <Skeleton className="mt-2 md:mt-4 h-5 w-24" />
+  </div>
+);
+
+export default function LoadingContributors() {
+  return (
+    <div className="space-y-12">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Code Contributors</h1>
+        <p className="text-gray-400 mt-2">
+          Special thanks to these amazing developers who have contributed to our
+          codebase.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8 mt-6">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <LoadingContributorCard key={i} />
+          ))}
+        </div>
+      </div>
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Design Contributors</h1>
+        <p className="text-gray-400 mt-2">
+          Our heartfelt appreciation to the creative minds behind our design.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8 mt-6">
+          {Array.from({ length: 1 }).map((_, i) => (
+            <LoadingContributorCard key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/contributors/page.tsx
+++ b/src/app/(public)/contributors/page.tsx
@@ -1,0 +1,121 @@
+import { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+export const metadata: Metadata = {
+  title: "Contributors",
+};
+
+type Contributor = {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+};
+
+type Designer = {
+  name: string;
+  avatar_url: string;
+  portfolio_url: string;
+};
+
+// Manually added designers as requested in the issue
+const designers: Designer[] = [
+  {
+    name: "Amir Faisal",
+    avatar_url: "https://avatars.githubusercontent.com/u/85594075?v=4",
+    portfolio_url: "https://github.com/amirfaisalz",
+  },
+];
+
+const ContributorCard = ({ contributor }: { contributor: Contributor }) => (
+  <div className="w-full border border-white flex flex-col justify-center items-center p-4 md:p-6 rounded-lg backdrop-blur-sm bg-green-600/10 transition-all hover:scale-105 hover:shadow-lg">
+    <Link href={contributor.html_url} target="_blank" rel="noopener noreferrer">
+      <Image
+        src={contributor.avatar_url}
+        alt={`${contributor.login}'s avatar`}
+        width={112}
+        height={112}
+        className="w-20 h-20 md:w-24 md:h-24 lg:w-28 lg:h-28 rounded-full border-4 border-primary"
+      />
+    </Link>
+    <h3 className="mt-3 md:mt-4 text-base md:text-lg text-center font-medium line-clamp-2">
+      {contributor.login}
+    </h3>
+    <p className="mt-1 text-sm text-gray-400">
+      {contributor.contributions} contributions
+    </p>
+  </div>
+);
+
+const DesignerCard = ({ designer }: { designer: Designer }) => (
+  <div className="w-full border border-white flex flex-col justify-center items-center p-4 md:p-6 rounded-lg backdrop-blur-sm bg-green-600/10 transition-all hover:scale-105 hover:shadow-lg">
+    <Link
+      href={designer.portfolio_url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Image
+        src={designer.avatar_url}
+        alt={`${designer.name}'s avatar`}
+        width={112}
+        height={112}
+        className="w-20 h-20 md:w-24 md:h-24 lg:w-28 lg:h-28 rounded-full border-4 border-primary"
+      />
+    </Link>
+    <h3 className="mt-3 md:mt-4 text-base md:text-lg text-center font-medium line-clamp-2">
+      {designer.name}
+    </h3>
+    <p className="mt-1 text-sm text-gray-400">Designer</p>
+  </div>
+);
+
+export default async function ContributorsPage() {
+  let contributors: Contributor[] = [];
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/Lampung-Dev/lampung-dev-web/contributors",
+      {
+        next: { revalidate: 3600 }, // Revalidate every hour
+      }
+    );
+    if (res.ok) {
+      contributors = await res.json();
+    } else {
+      console.error("Failed to fetch contributors:", res.statusText);
+    }
+  } catch (error) {
+    console.error("Error fetching contributors:", error);
+  }
+
+  return (
+    <div className="space-y-12">
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Code Contributors</h1>
+        <p className="text-gray-400 mt-2">
+          Special thanks to these amazing developers who have contributed to our
+          codebase.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8 mt-6">
+          {contributors.map((contributor) => (
+            <ContributorCard
+              key={contributor.login}
+              contributor={contributor}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h1 className="text-2xl md:text-3xl font-bold">Design Contributors</h1>
+        <p className="text-gray-400 mt-2">
+          Our heartfelt appreciation to the creative minds behind our design.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8 mt-6">
+          {designers.map((designer) => (
+            <DesignerCard key={designer.name} designer={designer} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav-main.tsx
+++ b/src/components/nav-main.tsx
@@ -28,8 +28,8 @@ export function NavMain({ nav }: { nav: TNavigation[] }) {
   };
 
   const isLinkActive = (url: string) => {
-    return pathname === url
-  }
+    return pathname === url;
+  };
 
   return (
     <SidebarGroup>
@@ -54,9 +54,11 @@ export function NavMain({ nav }: { nav: TNavigation[] }) {
                   <CollapsibleContent>
                     <SidebarMenuSub>
                       {item.items?.map((subItem) => (
-                        <SidebarMenuSubItem key={subItem.title}
-                        >
-                          <SidebarMenuSubButton asChild isActive={isLinkActive(subItem.url)}>
+                        <SidebarMenuSubItem key={subItem.title}>
+                          <SidebarMenuSubButton
+                            asChild
+                            isActive={isLinkActive(subItem.url)}
+                          >
                             <Link href={subItem.url}>
                               <span>{subItem.title}</span>
                             </Link>
@@ -68,7 +70,10 @@ export function NavMain({ nav }: { nav: TNavigation[] }) {
                 </>
               ) : (
                 <Link href={item.url} className="flex items-center space-x-2">
-                  <SidebarMenuButton tooltip={item.title} isActive={isLinkActive(item.url)}>
+                  <SidebarMenuButton
+                    tooltip={item.title}
+                    isActive={isLinkActive(item.url)}
+                  >
                     {item.icon && <item.icon size={16} />}
                     <span>{item.title}</span>
                   </SidebarMenuButton>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -5,49 +5,50 @@ import { Button } from "@/components/ui/button";
 import MobileNavigation from "./mobile-navigation";
 
 const menuItems = [
-    { title: 'About', href: '/about' },
-    { title: 'Events', href: '/our-events' },
-    { title: 'Members', href: '/members' },
+  { title: "About", href: "/about" },
+  { title: "Events", href: "/our-events" },
+  { title: "Members", href: "/members" },
+  { title: "Contributors", href: "/contributors" },
 ];
 
 export default async function Navbar() {
-    return (
-        <nav className="fixed top-0 w-full z-20 backdrop-blur-sm bg-black/10 border-b" >
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div className="flex justify-between items-center h-16">
-                    {/* Logo */}
-                    <div className="flex-shrink-0">
-                        <Link href="/" className="text-white text-xl font-bold">
-                            <Image
-                                src="/images/logo.png"
-                                alt="lampung-dev-logo"
-                                width={200}
-                                height={0}
-                                className="w-36 md:w-48 lg:w-52"
-                                priority
-                            />
-                        </Link>
-                    </div>
+  return (
+    <nav className="fixed top-0 w-full z-20 backdrop-blur-sm bg-black/10 border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          {/* Logo */}
+          <div className="flex-shrink-0">
+            <Link href="/" className="text-white text-xl font-bold">
+              <Image
+                src="/images/logo.png"
+                alt="lampung-dev-logo"
+                width={200}
+                height={0}
+                className="w-36 md:w-48 lg:w-52"
+                priority
+              />
+            </Link>
+          </div>
 
-                    {/* Desktop Navigation */}
-                    <div className="hidden md:flex items-center gap-8">
-                        {menuItems.map((item) => (
-                            <Link
-                                key={item.title}
-                                href={item.href}
-                                className="text-gray-300 hover:text-white transition-colors"
-                            >
-                                {item.title}
-                            </Link>
-                        ))}
-                        <Link href="/login">
-                            <Button className="bg-primary">Login</Button>
-                        </Link>
-                    </div>
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex items-center gap-8">
+            {menuItems.map((item) => (
+              <Link
+                key={item.title}
+                href={item.href}
+                className="text-gray-300 hover:text-white transition-colors"
+              >
+                {item.title}
+              </Link>
+            ))}
+            <Link href="/login">
+              <Button className="bg-primary">Login</Button>
+            </Link>
+          </div>
 
-                    <MobileNavigation menuItems={menuItems} />
-                </div>
-            </div>
-        </nav>
-    );
+          <MobileNavigation menuItems={menuItems} />
+        </div>
+      </div>
+    </nav>
+  );
 }


### PR DESCRIPTION
Resolves: [https://github.com/Lampung-Dev/lampung-dev-web/issues/16](https://github.com/Lampung-Dev/lampung-dev-web/issues/16)

#### Overview

This pull request introduces a new "Contributors" page to the website, as outlined in issue #16. The purpose of this page is to acknowledge and appreciate the individuals who have contributed to the development and design of the Lampung Dev website.

#### Changes Made

*   **New Contributors Page**: Created a new page at `/contributors` to showcase all project contributors.
*   **GitHub API Integration**: The page dynamically fetches and displays code contributors using the official GitHub API, ensuring the list is always up-to-date.
*   **Design Contributors Section**: A dedicated section has been added to manually feature design contributors, including their name, avatar, and a link to their portfolio.
*   **Loading State**: Implemented a skeleton loading screen using Next.js's `loading.tsx` file convention. This provides a better user experience by showing an instant UI while data is fetched on the server.
*   **Navigation Update**: Added a "Contributors" link to the main navigation bar for easy access from anywhere on the site.

#### How to Test

1.  Pull down this branch and run the application locally.
2.  Click on the new "Contributors" link in the main navigation bar.
3.  Observe the loading skeleton that appears while the contributor data is being fetched.
4.  Verify that the "Code Contributors" section populates correctly with data from the GitHub API.
5.  Verify that the "Design Contributors" section displays the manually added designers.
6.  Confirm that all links on the contributor cards (to GitHub profiles and portfolios) are correct and functional.
7.  Ensure the page is responsive and displays correctly on various screen sizes.