### PR TITLE
Add casual meetup 12 redirect link page

### DIFF
--- a/src/app/casual-meetup-12/page.tsx
+++ b/src/app/casual-meetup-12/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function RegisterPage() {
+  redirect('https://lu.ma/6r02on4l');
+}


### PR DESCRIPTION
## Description
This PR adds the redirect for Casual Meetup #12 registration. Users visiting the RegisterPage will be automatically redirected to the Luma event link.

**Changes**
- Implemented redirect from next/navigation in RegisterPage.
- Redirects users to: https://lu.ma/6r02on4l.

**Purpose**
To provide a direct and seamless way for participants to access the event registration page.