### PR TITLE
Add casual meetup 13 redirect page

### DIFF
--- a/src/app/casual-meetup-13/page.tsx
+++ b/src/app/casual-meetup-13/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function CasualMeetupThirteenPage() {
+  redirect("https://luma.com/km66r8lt");
+}


### PR DESCRIPTION
## Description
This update adds a redirect link for the Casual Meetup 13 event.
When users visit the CasualMeetupThirteenPage, they will be automatically redirected to the event registration page hosted on **Luma:**
https://luma.com/km66r8lt

**Implementation Details:**
- Added a redirect function from next/navigation inside CasualMeetupThirteenPage.
- Ensures that anyone accessing the registration route is taken directly to the external event link.

## Proof
https://www.loom.com/share/cd9576cd63d0485db56bfa4526559ec7?sid=a5884cb7-620a-43bc-812e-cedf37c557eb