### PR TITLE
Add Event link casual meetup #14

### DIFF
--- a/src/app/casual-meetup-14/page.tsx
+++ b/src/app/casual-meetup-14/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function CasualMeetupFourteenPage() {
+  redirect("https://luma.com/4zjl2pt9");
+}


### PR DESCRIPTION
## Description
This update adds a redirect link for the Casual Meetup 14 event.
When users visit the CasualMeetupFourteenPage, they will be automatically redirected to the event registration page hosted on **Luma:**
https://luma.com/4zjl2pt9

**Implementation Details:**
- Added a redirect function from next/navigation inside CasualMeetupFourteenPage.
- Ensures that anyone accessing the registration route is taken directly to the external event link.