### PR TITLE
Update custom api handle images event

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { getUserByEmailService } from "@/services/user";
 import { getUserRegistrationsService } from "@/services/event-registration";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { getEventImageUrl } from "@/lib/image-utils";
 import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = {
@@ -60,7 +61,7 @@ export default async function Page() {
               <Card key={id} className="overflow-hidden group hover:shadow-md transition-shadow">
                 <div className="relative aspect-square overflow-hidden">
                   <img
-                    src={event.imageUrl}
+                    src={getEventImageUrl(event.imageUrl)}
                     alt={event.title}
                     className="object-cover object-top w-full h-full transition-transform group-hover:scale-105"
                   />

--- a/src/app/(public)/our-events/[slug]/page.tsx
+++ b/src/app/(public)/our-events/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 
 import { auth } from "@/lib/next-auth";
+import { getEventImageUrl } from "@/lib/image-utils";
 import { getEventBySlugService, getEventRegisteredCountService } from "@/services/event";
 import { checkUserRegistrationService } from "@/services/event-registration";
 import { getUserByEmailService } from "@/services/user";
@@ -32,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     openGraph: {
       title: event.title,
       description: event.description.replace(/<[^>]*>/g, '').slice(0, 155),
-      images: [event.imageUrl],
+      images: [getEventImageUrl(event.imageUrl)],
     },
   };
 }
@@ -113,7 +114,7 @@ export default async function EventDetailPage({ params }: Props) {
         <div className="space-y-4">
           <div className="relative aspect-square rounded-2xl overflow-hidden shadow-xl">
             <Image
-              src={event.imageUrl}
+              src={getEventImageUrl(event.imageUrl)}
               alt={event.title}
               fill
               className="object-cover"

--- a/src/app/(public)/our-events/_components/event-card.tsx
+++ b/src/app/(public)/our-events/_components/event-card.tsx
@@ -6,6 +6,7 @@ import { Calendar, MapPin, Users, Instagram } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { TEventWithType } from "@/services/event";
+import { getEventImageUrl } from "@/lib/image-utils";
 
 type EventCardProps = {
   event: TEventWithType;
@@ -42,7 +43,7 @@ export function EventCard({ event, registeredCount = 0, isPast = false }: EventC
         {/* Square Image Container - Instagram Style */}
         <div className="relative aspect-square overflow-hidden">
           <Image
-            src={event.imageUrl}
+            src={getEventImageUrl(event.imageUrl)}
             alt={event.title}
             fill
             className="object-cover transition-transform duration-300 group-hover:scale-105"

--- a/src/app/api/upload/event/route.ts
+++ b/src/app/api/upload/event/route.ts
@@ -71,8 +71,8 @@ export async function POST(request: NextRequest) {
       .webp({ quality: 80 })
       .toFile(filepath);
 
-    // Return the public URL
-    const publicUrl = `/uploads/events/${filename}`;
+    // Return the public URL via API route (Next.js can't serve files uploaded after build)
+    const publicUrl = `/api/uploads/events/${filename}`;
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/uploads/events/[filename]/route.ts
+++ b/src/app/api/uploads/events/[filename]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readFile, stat } from "fs/promises";
+import path from "path";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ filename: string }> }
+) {
+  try {
+    const { filename } = await params;
+
+    // Validate filename to prevent directory traversal attacks
+    if (!filename || filename.includes("..") || filename.includes("/")) {
+      return NextResponse.json(
+        { error: "Invalid filename" },
+        { status: 400 }
+      );
+    }
+
+    // Only allow webp files for events
+    if (!filename.endsWith(".webp")) {
+      return NextResponse.json(
+        { error: "Invalid file type" },
+        { status: 400 }
+      );
+    }
+
+    // Construct the file path
+    const filepath = path.join(process.cwd(), "public", "uploads", "events", filename);
+
+    // Check if file exists
+    try {
+      await stat(filepath);
+    } catch {
+      return NextResponse.json(
+        { error: "File not found" },
+        { status: 404 }
+      );
+    }
+
+    // Read the file
+    const fileBuffer = await readFile(filepath);
+
+    // Return the file with proper headers
+    return new NextResponse(fileBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "image/webp",
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Length": fileBuffer.length.toString(),
+      },
+    });
+  } catch (error) {
+    console.error("Error serving file:", error);
+    return NextResponse.json(
+      { error: "Failed to serve file" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Transform event image URL to use API route
+ * This handles both old URLs (/uploads/events/...) and new URLs (/api/uploads/events/...)
+ * Needed because Next.js can't serve files uploaded after build time
+ */
+export function getEventImageUrl(imageUrl: string): string {
+  // If it's already using the API route, return as-is
+  if (imageUrl.startsWith('/api/uploads/events/')) {
+    return imageUrl;
+  }
+
+  // Transform old static path to API route
+  if (imageUrl.startsWith('/uploads/events/')) {
+    return imageUrl.replace('/uploads/events/', '/api/uploads/events/');
+  }
+
+  // For external URLs (http/https), return as-is
+  if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+    return imageUrl;
+  }
+
+  // Fallback: return as-is
+  return imageUrl;
+}


### PR DESCRIPTION
This pull request updates how event images are served and referenced throughout the application to ensure reliability, especially for images uploaded after build time. The main improvement is switching from serving images as static files to serving them through a new API route, with a utility function to handle the URL transformation. This ensures images work correctly regardless of deployment or build timing.

**Image serving and URL transformation:**

* Added a new API route at `/api/uploads/events/[filename]` to serve event images securely, with validation and appropriate headers. This addresses the limitation that Next.js cannot serve files uploaded after build time. ([src/app/api/uploads/events/[filename]/route.tsR1-R60](diffhunk://#diff-0d76fe544517c27feb200e11be2bf47c427b907035833a6da4a0aa8ada1bd7c1R1-R60))
* Introduced the `getEventImageUrl` utility in `image-utils.ts` to consistently transform image URLs to use the new API route, handling both legacy and external URLs.

**Codebase updates to use the new image handling:**

* Updated all event image references in the dashboard, event detail, and event card components to use `getEventImageUrl`, ensuring images are loaded via the API route. (`dashboard/page.tsx`, `(public)/our-events/[slug]/page.tsx`, `(public)/our-events/_components/event-card.tsx`) [[1]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721R9) [[2]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L63-R64) [src/app/(public)/our-events/[slug]/page.tsxR11](diffhunk://#diff-7f0216a7c1966074f75418596b0cc91646f6adeca841f8639a2729f2996a8decR11), [src/app/(public)/our-events/[slug]/page.tsxL35-R36](diffhunk://#diff-7f0216a7c1966074f75418596b0cc91646f6adeca841f8639a2729f2996a8decL35-R36), [src/app/(public)/our-events/[slug]/page.tsxL116-R117](diffhunk://#diff-7f0216a7c1966074f75418596b0cc91646f6adeca841f8639a2729f2996a8decL116-R117), [[3]](diffhunk://#diff-3e35040a3b69ad9896af742b023fae05cd25f1f4397db1835cad6b182d0162c8R9) [[4]](diffhunk://#diff-3e35040a3b69ad9896af742b023fae05cd25f1f4397db1835cad6b182d0162c8L45-R46)

**Upload endpoint update:**

* Changed the event image upload endpoint to return URLs pointing to the new API route instead of the static path, ensuring consistency for newly uploaded images.