### PR TITLE
fix(auth & profile): fix account self-deletion re-creation and input null value errors

### DIFF
--- a/src/app/(dashboard)/__components/profile-form.tsx
+++ b/src/app/(dashboard)/__components/profile-form.tsx
@@ -13,11 +13,11 @@ import { updateUserAction } from "@/actions/update-user-action";
 import { Separator } from "@/components/ui/separator";
 
 export default function ProfileForm({ user }: { user: UserProfile }) {
-    const [name, setName] = useState(user.name);
-    const [email, setEmail] = useState(user.email);
-    const [title, setTitle] = useState(user.title);
+    const [name, setName] = useState(user.name || "");
+    const [email, setEmail] = useState(user.email || "");
+    const [title, setTitle] = useState(user.title || "");
     const [socialMediaLinks, setSocialMediaLinks] = useState<SocialMediaLink[]>(
-        []
+        user.socialMediaLinks || []
     );
     const [isLoading, setIsLoading] = useState(false);
     const [errors, setErrors] = useState<{
@@ -84,8 +84,8 @@ export default function ProfileForm({ user }: { user: UserProfile }) {
     };
 
     useEffect(() => {
-        setName(user.name);
-        setEmail(user.email);
+        setName(user.name || "");
+        setEmail(user.email || "");
         setTitle(user.title || "");
         setSocialMediaLinks(user.socialMediaLinks || []);
     }, [user]);
@@ -101,7 +101,7 @@ export default function ProfileForm({ user }: { user: UserProfile }) {
                     type="text"
                     id="name"
                     placeholder="Name"
-                    value={name}
+                    value={name || ""}
                     onChange={handleNameChange}
                     className={errors.name ? "border-red-500" : ""}
                     required
@@ -118,7 +118,7 @@ export default function ProfileForm({ user }: { user: UserProfile }) {
                     type="email"
                     id="email"
                     placeholder="Email"
-                    value={email}
+                    value={email || ""}
                     className="cursor-not-allowed"
                     readOnly
                 />
@@ -133,7 +133,7 @@ export default function ProfileForm({ user }: { user: UserProfile }) {
                     type="text"
                     id="title"
                     placeholder="Title"
-                    value={title}
+                    value={title || ""}
                     onChange={handleTitleChange}
                     className={errors.title ? "border-red-500" : ""}
                     required

--- a/src/app/(dashboard)/__components/select-platform.tsx
+++ b/src/app/(dashboard)/__components/select-platform.tsx
@@ -155,7 +155,7 @@ export default function SelectPlatform({
                                 <Input
                                     type="url"
                                     placeholder="https://"
-                                    value={link.url}
+                                    value={link.url || ""}
                                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                                         updateSocialMedia(index, 'url', e.target.value)}
                                     maxLength={100}

--- a/src/app/(dashboard)/users/my-profile/page.tsx
+++ b/src/app/(dashboard)/users/my-profile/page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { toast } from 'sonner';
 import { auth } from '@/lib/next-auth';
 import { UserProfile } from '@/types/user';
 import { getUserByEmailService } from '@/services/user';
@@ -14,9 +13,9 @@ export default async function Page() {
     if (!session) return
 
     const user: UserProfile = {
-        avatar: session.user?.image as string,
-        email: session.user?.email as string,
-        name: session.user?.name as string,
+        avatar: (session.user?.image as string) || '',
+        email: (session.user?.email as string) || '',
+        name: (session.user?.name as string) || '',
         title: '',
         role: 'USER',
         hasPassword: false,
@@ -27,16 +26,15 @@ export default async function Page() {
         const userData = await getUserByEmailService(session?.user?.email as string)
 
         if (userData) {
-            user.avatar = userData?.picture as string
-            user.name = userData.name as string
-            user.title = userData?.title as string
-            user.role = userData.role as string
-            user.hasPassword = userData.hasPassword
-            user.socialMediaLinks = userData?.socialMediaLinks
+            user.avatar = userData.picture || user.avatar || ''
+            user.name = userData.name || user.name || ''
+            user.title = userData.title || ''
+            user.role = userData.role || 'USER'
+            user.hasPassword = !!userData.hasPassword
+            user.socialMediaLinks = userData.socialMediaLinks || []
         }
     } catch (error) {
         console.log('ERROR get user data in my profile page:', error)
-        toast("error get user")
     }
 
     return (

--- a/src/lib/next-auth/index.ts
+++ b/src/lib/next-auth/index.ts
@@ -20,51 +20,81 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
         }),
     ],
     callbacks: {
-        async session(params) {
+        async signIn({ user }) {
             try {
-                const existingUser = await getUserByEmailService(params.session.user.email)
+                if (!user?.email) return false;
+
+                const existingUser = await getUserByEmailService(user.email);
 
                 if (!existingUser) {
-                    // If user doesn't exist, create a new user
+                    // Create new user ONLY during actual login
                     const [newUser] = await createUserService({
-                        name: params.session.user.name!,
-                        email: params.session.user.email,
-                        picture: params.session.user.image!,
+                        name: user.name || "Anonymous Member",
+                        email: user.email,
+                        picture: user.image || "/images/placeholder-image.jpeg",
                         passwordHash: null,
                         title: null,
-                        companyId: null
-                    })
+                        companyId: null,
+                    });
 
                     await creatSessionService({
                         userId: newUser.id,
-                        expiresAt: new Date(params.session.expires),
-                    })
-                } else {
-                    const existingSession = await getSessionByUserIdService(existingUser.id as string)
-
-                    await updateSessionService({
-                        expiresAt: new Date(params.session.expires),
-                        sessionId: existingSession?.id as string
-                    })
-
-                    // Add role and companyId to session user
-                    if (params.session.user) {
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-expect-error
-                        params.session.user.role = existingUser.role;
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-expect-error
-                        params.session.user.companyId = existingUser.companyId;
-                    }
+                        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+                    });
+                } else if (existingUser.status === "BANNED") {
+                    return false;
                 }
 
-                return params.session
+                return true;
+            } catch (error) {
+                console.error("Error in signIn callback:", error);
+                return false;
+            }
+        },
+        async session(params) {
+            try {
+                if (!params.session?.user?.email) {
+                    return params.session;
+                }
 
+                const existingUser = await getUserByEmailService(params.session.user.email);
+
+                // If user was deleted or is banned, do NOT recreate them!
+                if (!existingUser || existingUser.status === "BANNED") {
+                    // Invalidate user from session
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    params.session.user = null;
+                    return params.session;
+                }
+
+                const existingSession = await getSessionByUserIdService(existingUser.id as string);
+
+                if (existingSession) {
+                    await updateSessionService({
+                        expiresAt: new Date(params.session.expires),
+                        sessionId: existingSession.id as string,
+                    });
+                }
+
+                // Add id, role, and companyId to session user
+                if (params.session.user) {
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    params.session.user.id = existingUser.id;
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    params.session.user.role = existingUser.role;
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    params.session.user.companyId = existingUser.companyId;
+                }
+
+                return params.session;
             } catch (error) {
                 console.error("Error in session callback:", error);
-                throw error;
+                return params.session;
             }
-        }
-
+        },
     },
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -23,10 +23,10 @@ export const creatSessionService = async (values: TNewSession) => {
 
 }
 
-export const getSessionByUserIdService = async (id: string) => {
+export const getSessionByUserIdService = async (userId: string) => {
     try {
         return await db.query.sessionTable.findFirst({
-            where: eq(sessionTable.id, id),
+            where: eq(sessionTable.userId, userId),
         });
     } catch (error) {
         console.log('ERROR getSessionByUserIdService:', error)


### PR DESCRIPTION
## 📌 Summary
Follow-up fixes for #52:
1. **Auth / Account Deletion**: Fixed an issue where deleted users were resurrected by NextAuth's `session` callback due to user creation logic running during session checks. Moved new user creation exclusively to the `signIn` OAuth callback and properly invalidated sessions for deleted/banned users.
2. **Profile Form**: Fixed React runtime warnings/errors where `null` values from the database were passed to `<Input />` components without fallbacks, causing controlled/uncontrolled state errors.
3. **Session Query**: Fixed `getSessionByUserIdService` to query `sessionTable.userId` correctly.

## 🧪 Verification
- `bun run lint` (0 errors)
- Tested account self-deletion and verified permanent deletion.
- Tested `/users/my-profile` with empty/null title fields.