### PR TITLE
fix(auth & profile): fix account self-deletion re-creation, input null value errors, and build types

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -12,18 +12,16 @@ import BreadCrumbDashboard from "./__components/bread-crumb-dashboard";
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
     const session = await auth();
 
-    if (!session) {
+    if (!session || !session.user) {
         redirect('/login');
     }
 
     const user = {
-        name: session.user?.name as string,
-        email: session.user?.email as string,
-        avatar: session.user?.image as string,
-        // @ts-expect-error - next-auth types don't include custom role field
-        role: session.user?.role as string,
-        // @ts-expect-error - next-auth types don't include custom companyId field
-        companyId: session.user?.companyId as string | undefined,
+        name: session.user.name as string,
+        email: session.user.email as string,
+        avatar: session.user.image as string,
+        role: session.user.role as string,
+        companyId: session.user.companyId as string | undefined,
     };
 
     return (
@@ -47,4 +45,3 @@ export default async function DashboardLayout({ children }: { children: React.Re
         </div>
     );
 }
-

--- a/src/lib/next-auth/index.ts
+++ b/src/lib/next-auth/index.ts
@@ -62,10 +62,10 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
                 // If user was deleted or is banned, do NOT recreate them!
                 if (!existingUser || existingUser.status === "BANNED") {
                     // Invalidate user from session
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
-                    params.session.user = null;
-                    return params.session;
+                    return {
+                        ...params.session,
+                        user: undefined as unknown as typeof params.session.user,
+                    };
                 }
 
                 const existingSession = await getSessionByUserIdService(existingUser.id as string);
@@ -79,14 +79,8 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
 
                 // Add id, role, and companyId to session user
                 if (params.session.user) {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
                     params.session.user.id = existingUser.id;
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
                     params.session.user.role = existingUser.role;
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
                     params.session.user.companyId = existingUser.companyId;
                 }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,16 @@
+import { type DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+    interface Session {
+        user?: {
+            id?: string;
+            role?: string;
+            companyId?: string | null;
+        } & DefaultSession["user"];
+    }
+
+    interface User {
+        role?: string;
+        companyId?: string | null;
+    }
+}


### PR DESCRIPTION
## 📌 Summary
Follow-up fixes for #52:
1. **Auth / Account Deletion**: Fixed an issue where deleted users were resurrected by NextAuth's `session` callback. User creation is now exclusively handled during OAuth `signIn` callback, and sessions are properly invalidated for deleted/banned accounts.
2. **Profile Form**: Fixed React runtime warnings/errors where `null` values from the database were passed to `<Input />` components without fallbacks, causing controlled/uncontrolled state errors.
3. **Session Query**: Fixed `getSessionByUserIdService` to query `sessionTable.userId` correctly.
4. **TypeScript & CI Build**: Added `src/types/next-auth.d.ts` module augmentation for NextAuth session user (`id`, `role`, `companyId`) and removed unused `@ts-expect-error` directives that caused CI build failures.

## 🧪 Verification
- `bun run lint` (0 errors)
- `bun run build` (50/50 static/dynamic pages compiled successfully)