### PR TITLE
ci: enforce strict failure on deployment webhook errors and log response

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,22 @@ jobs:
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
         run: |
-          if [ -n "$COOLIFY_WEBHOOK_URL" ]; then
-            echo "Triggering Coolify deployment..."
-            curl -f -s -X GET "$COOLIFY_WEBHOOK_URL"
-            echo "Coolify deployment triggered successfully."
-          else
-            echo "COOLIFY_WEBHOOK_URL not set for this environment. Skipping deployment trigger."
+          if [ -z "$COOLIFY_WEBHOOK_URL" ]; then
+            echo "::error::COOLIFY_WEBHOOK_URL is not configured for this environment. Deployment failed."
+            exit 1
           fi
+
+          echo "Triggering Coolify deployment..."
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X GET "$COOLIFY_WEBHOOK_URL")
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d':' -f2)
+          BODY=$(echo "$RESPONSE" | grep -v "HTTP_STATUS:")
+
+          echo "Coolify Response (HTTP $HTTP_STATUS):"
+          echo "$BODY"
+
+          if [ -z "$HTTP_STATUS" ] || [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "::error::Coolify deployment failed with HTTP status $HTTP_STATUS"
+            exit 1
+          fi
+
+          echo "Coolify deployment triggered successfully."


### PR DESCRIPTION
## Description
Improves the deployment workflow to strictly fail the CI job when the deployment webhook fails or when `COOLIFY_WEBHOOK_URL` is missing, and logs the HTTP status code and response body for debugging.

## Changes Made
- Added missing secret validation: fails with error if `COOLIFY_WEBHOOK_URL` is not set for the environment.
- Logs HTTP status code and response body from Coolify.
- Fails the job if the HTTP status code is not 2xx.