### PR TITLE
chore(docker): add pull_policy always to docker-compose web service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Display current application version in the footer UI linking to `CHANGELOG.md` ([#74](https://github.com/Lampung-Dev/lampung-dev-web/issues/74))
 - Establish SemVer version bumping policy & workflow in `README.md`
 - Add GitHub Pull Request template with SemVer and CHANGELOG checklist
+- Configure `pull_policy: always` in `docker-compose.yaml` to ensure latest Docker image is pulled during deployments
 
 ## [1.5.2] - 2025-07-20
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    pull_policy: always
     container_name: lampungdev-web
     ports:
       - "3050:3050"


### PR DESCRIPTION
## Description
Add `pull_policy: always` to `docker-compose.yaml` web service to ensure Docker Compose always pulls the latest container image when deploying rather than using a stale local cached image.

## Type of Change
- [x] 📝 Documentation update / Chore

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have updated `CHANGELOG.md` with a summary of the changes
- [x] My changes generate no new warnings or errors