### PR TITLE
chore: bump package version to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lampung-dev-web",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3050",


### PR DESCRIPTION
## Description
Bump package version to 1.6.1 to test auto-deployment pipeline.

## Changes
- Bump `version` in `package.json` from `1.6.0` to `1.6.1`