### PR TITLE
chore: bump package version to 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.2] - 2026-08-20
+
+### What's Changed
+
+- Test auto-deployment pipeline with version 1.6.2
+
 ## [1.6.0] - 2026-08-20
 
 ### What's Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lampung-dev-web",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 3050",


### PR DESCRIPTION
## Description
Bump package version to 1.6.2 to test the fixed auto-deployment pipeline on Coolify.

## Changes
- Bump `version` in `package.json` from `1.6.1` to `1.6.2`
- Add `[1.6.2]` entry in `CHANGELOG.md`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have updated `CHANGELOG.md` with a summary of the changes
- [x] My changes generate no new warnings or errors